### PR TITLE
Fix failed tests and crash on MinGW.

### DIFF
--- a/r128.h
+++ b/r128.h
@@ -795,7 +795,7 @@ static void r128__umul128(R128 *dst, R128_U64 a, R128_U64 b)
 }
 
 // 128/64->64
-#if defined(_M_X64) && (_MSC_VER < 1920) && !defined(R128_STDC_ONLY)
+#if defined(_M_X64) && (_MSC_VER < 1920) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__)
 // MSVC x64 provides neither inline assembly nor (pre-2019) a div intrinsic, so we do fake
 // "inline assembly" to avoid long division or outline assembly.
 #pragma code_seg(".text")
@@ -810,7 +810,7 @@ static const r128__udiv128Proc r128__udiv128 = (r128__udiv128Proc)(void*)r128__u
 #else
 static R128_U64 r128__udiv128(R128_U64 nlo, R128_U64 nhi, R128_U64 d, R128_U64 *rem)
 {
-#if defined(_M_X64) && !defined(R128_STDC_ONLY)
+#if defined(_M_X64) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__)
    return _udiv128(nhi, nlo, d, rem);
 #elif defined(__x86_64__) && !defined(R128_STDC_ONLY)
    R128_U64 q, r;

--- a/test/test.c
+++ b/test/test.c
@@ -6,6 +6,11 @@
 #ifndef NDEBUG
 #  define R128_DEBUG_VIS
 #endif
+
+#ifdef __MINGW32__
+#  define __USE_MINGW_ANSI_STDIO 1 // force standard sprintf precision
+#endif
+
 #include "../r128.h"
 
 #include <math.h>


### PR DESCRIPTION
- Fix failed tests (MinGW default `sprintf` precision).
- Fix crash (use of incompatible MSVC x64 pseudo-inline assembly).

Tested with following compilers:
- clang 10.0.0 and GCC 9.3.0 on Ubuntu 20.04
- clang 10.0.0 and GCC 10.1.0 on MSYS2 MinGW
- MSVC 2019 (cl 19.25.28614) on Windows 10

Fixes #9