### PR TITLE
Fix build errors when building 32-bit binary on MinGW.

### DIFF
--- a/r128.h
+++ b/r128.h
@@ -665,7 +665,7 @@ static int r128__clz64(R128_U64 x)
 // 32*32->64
 static R128_U64 r128__umul64(R128_U32 a, R128_U32 b)
 {
-#  if defined(_M_IX86) && !defined(R128_STDC_ONLY)
+#  if defined(_M_IX86) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__)
    return __emulu(a, b);
 #  elif defined(_M_ARM) && !defined(R128_STDC_ONLY)
    return _arm_umull(a, b);
@@ -680,7 +680,7 @@ static R128_U32 r128__udiv64(R128_U32 nlo, R128_U32 nhi, R128_U32 d, R128_U32 *r
 #  if defined(_M_IX86) && (_MSC_VER >= 1920) && !defined(R128_STDC_ONLY)
    unsigned __int64 n = ((unsigned __int64)nhi << 32) | nlo;
    return _udiv64(n, d, rem);
-#  elif defined(_M_IX86) && !defined(R128_STDC_ONLY)
+#  elif defined(_M_IX86) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__)
    __asm {
       mov eax, nlo
       mov edx, nhi
@@ -1602,7 +1602,7 @@ void r128Shl(R128 *dst, const R128 *src, int amount)
    R128_ASSERT(dst != NULL);
    R128_ASSERT(src != NULL);
 
-#if defined(_M_IX86) && !defined(R128_STDC_ONLY)
+#if defined(_M_IX86) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__)
    __asm {
       // load src
       mov edx, dword ptr[src]
@@ -1664,7 +1664,7 @@ void r128Shr(R128 *dst, const R128 *src, int amount)
    R128_ASSERT(dst != NULL);
    R128_ASSERT(src != NULL);
 
-#if defined(_M_IX86) && !defined(R128_STDC_ONLY)
+#if defined(_M_IX86) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__)
    __asm {
       // load src
       mov edx, dword ptr[src]
@@ -1726,7 +1726,7 @@ void r128Sar(R128 *dst, const R128 *src, int amount)
    R128_ASSERT(dst != NULL);
    R128_ASSERT(src != NULL);
 
-#if defined(_M_IX86) && !defined(R128_STDC_ONLY)
+#if defined(_M_IX86) && !defined(R128_STDC_ONLY) && !defined(__MINGW32__)
    __asm {
       // load src
       mov edx, dword ptr[src]


### PR DESCRIPTION
Fixes use of MSVC style inline assembly and MSVC `__emulu` function in 32-bit MinGW builds.

Tested with the following compilers (both 32-bit and 64-bit builds):

- clang 10.0.0 and GCC 9.3.0 on Ubuntu 20.04
- clang 10.0.0 and GCC 10.1.0 on MSYS2 MinGW
- MSVC 2019 (cl 19.25.28614) on Windows 10
