### PR TITLE
Disable deprecated denorm funcs in C++23

### DIFF
--- a/r128.h
+++ b/r128.h
@@ -302,8 +302,10 @@ struct numeric_limits<R128>
    static const bool has_infinity = false;
    static const bool has_quiet_NaN = false;
    static const bool has_signaling_NaN = false;
+#if !(__cplusplus > 202002L || (defined(_MSVC_LANG) && _MSVC_LANG > 202002L))
    static const float_denorm_style has_denorm = denorm_absent;
    static const bool has_denorm_loss = false;
+#endif
 
    static R128 infinity() throw() { return R128_zero; }
    static R128 quiet_NaN() throw() { return R128_zero; }


### PR DESCRIPTION
Starting with C++23, `float_denorm_style`, `numeric_limits::has_denorm`, and `numeric_limits::has_denorm_loss` are considered deprecated. This PR simply disables them outright if compiling for C++23 or later.